### PR TITLE
Fix warning on Arduino IDE 2.0

### DIFF
--- a/SerialRecord.h
+++ b/SerialRecord.h
@@ -206,7 +206,7 @@ class SerialRecord {
   };
   ReadState m_readState = LINE_START;
 
-  void reportInvalidCharacter(char *message, int c) {
+  void reportInvalidCharacter(const char *message, int c) {
     if (firstLine) return;
 
     Serial.print(message);


### PR DESCRIPTION
GCC bundled with Arduino IDE 2.0 produces the following warnings with the "Compiler warnings: Default" setting (or higher): ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]